### PR TITLE
Use display_name for images, update routes for eecs-autograder/autograder-server@f6ed31c

### DIFF
--- a/export_project.py
+++ b/export_project.py
@@ -24,7 +24,7 @@ def main():
     ag_test_json = _download_json(
         client, f'/api/projects/{args.project_id}/ag_test_suites/')
     mutation_test_json = _download_json(
-        client, f'/api/projects/{args.project_id}/student_test_suites/')
+        client, f'/api/projects/{args.project_id}/mutation_test_suites/')
 
     handgrading_json = None
     if project_json['has_handgrading_rubric']:

--- a/import_project.py
+++ b/import_project.py
@@ -57,9 +57,15 @@ def _create_project(client, course_id, project_json, project_name=None):
 
 def _load_sandbox_images(client, course_id):
     # Update when we deploy 4.0 to include course-linked images
-    response = client.get(f'/api/courses/{course_id}/sandbox_docker_images/')
-    check_response_status(response)
-    return {item['display_name']: item for item in response.json()}
+    global_images_response = client.get('/api/sandbox_docker_images/')
+    course_images_response = client.get(f'/api/courses/{course_id}/sandbox_docker_images/')
+
+    check_response_status(global_images_response)
+    check_response_status(course_images_response)
+
+    available_images = global_images_response.json() + course_images_response.json()
+
+    return {item['display_name']: item for item in available_images}
 
 
 def _import_instructor_files(client, project_pk, instructor_files_dir):

--- a/import_project.py
+++ b/import_project.py
@@ -57,9 +57,9 @@ def _create_project(client, course_id, project_json, project_name=None):
 
 def _load_sandbox_images(client, course_id):
     # Update when we deploy 4.0 to include course-linked images
-    response = client.get('/api/sandbox_docker_images/')
+    response = client.get(f'/api/courses/{course_id}/sandbox_docker_images/')
     check_response_status(response)
-    return {item['name']: item for item in response.json()}
+    return {item['display_name']: item for item in response.json()}
 
 
 def _import_instructor_files(client, project_pk, instructor_files_dir):
@@ -99,7 +99,7 @@ def _create_ag_tests(
         request_body = dict(suite_json)
         request_body.pop('ag_test_cases')
         request_body['sandbox_docker_image'] = (
-            sandbox_docker_images[suite_json['sandbox_docker_image']['name']])
+            sandbox_docker_images[suite_json['sandbox_docker_image']['display_name']])
         request_body['instructor_files_needed'] = [
             instructor_files[file_json['name']]
             for file_json in suite_json['instructor_files_needed']
@@ -159,7 +159,7 @@ def _create_mutation_test_suites(
     for suite_json in mutation_test_json:
         request_body = dict(suite_json)
         request_body['sandbox_docker_image'] = (
-            sandbox_docker_images[suite_json['sandbox_docker_image']['name']])
+            sandbox_docker_images[suite_json['sandbox_docker_image']['display_name']])
         request_body['instructor_files_needed'] = [
             instructor_files[file_json['name']]
             for file_json in suite_json['instructor_files_needed']
@@ -170,7 +170,7 @@ def _create_mutation_test_suites(
         ]
 
         suite_response = client.post(
-            f'/api/projects/{project_pk}/student_test_suites/', json=request_body)
+            f'/api/projects/{project_pk}/mutation_test_suites/', json=request_body)
         check_response_status(suite_response)
         suite = suite_response.json()
         result.append(suite)


### PR DESCRIPTION
Updates to make the script work against the latest changes from autograder-server, most importantly the change from `student_test_suites` to `mutation_test_suites`.

One point is a bit unclear: all references to sandbox image were using the `name` field, but it doesn't seem like this is returned from the API so the script was getting key errors. Additionally, it was getting global sandbox images not tied to any particular course.

I switched to using `display_name` as this is what export_project.py seems to dump into `ag_tests.json`, and I switched to using the route that gets all sandbox images for the relevant course. `display_name` is unique within courses so this should be OK I believe.